### PR TITLE
Fix sanitize_filename behavior

### DIFF
--- a/app/state_manager.py
+++ b/app/state_manager.py
@@ -7,9 +7,7 @@ import re
 
 def sanitize_filename(name: str) -> str:
     """Sanitizes a string to be a valid filename."""
-    # Remove characters that are invalid on many filesystems (e.g. backslash or pipe)
-    name = re.sub(r'[\\|]', '', name)
-    # Replace any remaining invalid characters with an underscore
+    # Replace characters not allowed in filenames with an underscore
     return re.sub(r'[^a-zA-Z0-9_-]', '_', name)
 
 class StateManager:


### PR DESCRIPTION
## Summary
- update sanitize_filename to always replace invalid characters
- keep replacements consistent for characters like `\` and `|`

## Testing
- `pytest tests/unit/test_state_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_b_684c2dea9d388326939ab63d8998f519