### PR TITLE
Add GUI display requirement note

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,24 @@ python run_gui.py
 ```
 If there's a different main script, use that instead (e.g., `python main.py`).
 
+`run_gui.py` launches a Tkinter-based window and therefore requires access to a
+graphical display. On a headless server the script may fail to start unless you
+provide a virtual display (e.g., via `xvfb-run`) or connect through remote
+desktop.
+
+```bash
+xvfb-run -a python run_gui.py
+```
+
+If you have already created your profiles with the GUI you can run the bot
+without the interface using the command-line helper:
+
+```bash
+python manual_run.py
+```
+This reads the profiles stored in `data/profiles.json` and runs the automation
+directly in the console.
+
 Check the console output and log files (e.g., in a `logs` directory or `automation_test.log`) for activity, status updates, and any errors.
 
 ## Documentation

--- a/docs/user_guide_setup.md
+++ b/docs/user_guide_setup.md
@@ -129,6 +129,21 @@ If you want to encrypt sensitive information like your job site or email passwor
     ```
     (If a different main script exists, like `main_cli.py`, use that.)
 
+    `run_gui.py` opens a graphical window. On servers without a display the
+    script may fail to start. Use a virtual display such as **Xvfb** or connect
+    via remote desktop:
+
+    ```bash
+    xvfb-run -a python run_gui.py
+    ```
+
+    If profiles have already been created with the GUI you can run the bot in
+    the terminal using:
+
+    ```bash
+    python manual_run.py
+    ```
+
 ### Monitoring
 -   **Console Output:** The bot will print log messages to the console, showing its current activities, jobs found, errors, etc.
 -   **Log Files:** Detailed logs are typically saved to a file (e.g., `automation_test.log` or in a `logs/` directory). Check `app/logger.py` for the configured log file path. These logs are essential for debugging.


### PR DESCRIPTION
## Summary
- document that `run_gui.py` needs a graphical display
- explain how to use `xvfb-run` or run `manual_run.py` when on a headless server

## Testing
- `pytest -q` *(fails: FileNotFoundError in `final_working_test.py`, assertion failure in `tests/unit/test_state_manager.py`)*
