### PR TITLE
Fix master key prompt handling

### DIFF
--- a/app/gui.py
+++ b/app/gui.py
@@ -154,9 +154,13 @@ class App(ctk.CTk):
             password = simpledialog.askstring("Master Password", "Please enter your Master Password:", show='*')
             if password is None: # User cancelled
                 return False
-            
-            with open(MASTER_KEY_HASH_PATH, 'rb') as f:
-                stored_hash = f.read()
+
+            try:
+                with open(MASTER_KEY_HASH_PATH, 'rb') as f:
+                    stored_hash = f.read()
+            except FileNotFoundError:
+                messagebox.showerror("Error", "Master key not found. Run the setup wizard again or check your installation.")
+                return False
             
             if security.verify_password(stored_hash, password):
                 self.master_password = password

--- a/app/state_manager.py
+++ b/app/state_manager.py
@@ -7,7 +7,9 @@ import re
 
 def sanitize_filename(name: str) -> str:
     """Sanitizes a string to be a valid filename."""
-    # Replace characters not allowed in filenames with an underscore
+    # Remove characters that are invalid on many filesystems (e.g. backslash or pipe)
+    name = re.sub(r'[\\|]', '', name)
+    # Replace any remaining invalid characters with an underscore
     return re.sub(r'[^a-zA-Z0-9_-]', '_', name)
 
 class StateManager:


### PR DESCRIPTION
## Summary
- catch missing master key file when prompting for password
- sanitize filenames by removing `\` and `|` before replacing invalid chars

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_b_684c34b9122483268c3afb660075e80c