### PR TITLE
Fix manual_run script and location filtering

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -44,10 +44,10 @@ def filter_jobs(jobs: List[Dict[str, str]], keywords_config: Dict, filters_confi
         
         # Check location filter
         if allowed_cities and not any(city in location_lower for city in allowed_cities):
-            # Allow job if location is empty/not specified, as it could be a remote role
-            if location_lower.strip():
-                log.debug(f"Skipping job '{job['title']}' in '{job.get('location')}' - location not in allowed list: {allowed_cities}")
-                continue
+            log.debug(
+                f"Skipping job '{job['title']}' in '{job.get('location')}' - location not in allowed list: {allowed_cities}"
+            )
+            continue
             
         filtered_jobs.append(job)
         

--- a/app/main.py
+++ b/app/main.py
@@ -53,7 +53,14 @@ def filter_jobs(jobs: List[Dict[str, str]], keywords_config: Dict, filters_confi
         
     return filtered_jobs
 
-def run_bot(profile_name: str, profile_config: Dict, master_password: str, stop_event: threading.Event, status_queue: queue.Queue):
+def run_bot(
+    profile_name: str,
+    profile_config: Dict,
+    master_password: str,
+    stop_event: threading.Event,
+    status_queue: queue.Queue,
+    log_queue: queue.Queue | None = None,
+):
     """
     Main function to run the Sentinel Bot for a specific profile.
     This function is stateless and receives all config as arguments.

--- a/manual_run.py
+++ b/manual_run.py
@@ -66,7 +66,14 @@ def test_bot():
         # Start bot in background thread
         bot_thread = threading.Thread(
             target=run_bot,
-            args=(profile_name, profile_config, master_password, stop_event, status_queue)
+            args=(
+                profile_name,
+                profile_config,
+                master_password,
+                stop_event,
+                status_queue,
+                log_queue,
+            ),
         )
         bot_thread.daemon = True
         bot_thread.start()

--- a/manual_run.py
+++ b/manual_run.py
@@ -65,8 +65,8 @@ def test_bot():
         
         # Start bot in background thread
         bot_thread = threading.Thread(
-            target=run_bot, 
-            args=(profile_name, profile_config, stop_event, status_queue)
+            target=run_bot,
+            args=(profile_name, profile_config, master_password, stop_event, status_queue)
         )
         bot_thread.daemon = True
         bot_thread.start()


### PR DESCRIPTION
## Summary
- pass `master_password` to `run_bot` in `manual_run.py`
- update `filter_jobs` to exclude jobs without a matching city

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684c7a2b7a1483269da347722fd5a1eb