### PR TITLE
Fix docs field name

### DIFF
--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -115,7 +115,7 @@ Based on the `job_site_type`, you'll need to provide a corresponding site-specif
     *   `title: string` (e.g., `"h3[class*='job-title']"`)
     *   `company: string` (Optional, e.g., `"[class*='company-name']"`; often defaults to "Amazon")
     *   `location: string` (e.g., `"[class*='job-location']"`)
-    *   `link: string` (e.g., `"a[class*='job-link']"`)
+    *   `url: string` (e.g., `"a[class*='job-link']"`)
     *   Example:
         ```yaml
         amazon_config:
@@ -126,7 +126,7 @@ Based on the `job_site_type`, you'll need to provide a corresponding site-specif
             job_card: ".job-tile"
             title: ".job-title"
             location: ".location"
-            link: "a.job-link"
+            url: "a.job-link"
           # cookie_modal_selectors and page_signatures would also go under amazon_config
         ```
 *   **`cookie_modal_selectors`** (list[string], Optional)
@@ -158,7 +158,7 @@ Based on the `job_site_type`, you'll need to provide a corresponding site-specif
     *   `title: string` (e.g., `"h2.jobTitle > a"`)
     *   `company: string` (e.g., `"[data-testid='company-name']"`)
     *   `location: string` (e.g., `"[data-testid='text-location']"`)
-    *   `link: string` (e.g., `"h2.jobTitle > a"`)
+    *   `url: string` (e.g., `"h2.jobTitle > a"`)
     *   `description_snippet: string` (e.g., `".job-snippet"`)
     *   Example:
         ```yaml
@@ -170,7 +170,7 @@ Based on the `job_site_type`, you'll need to provide a corresponding site-specif
             title: "h2.jobTitle > a"
             company: "[data-testid='company-name']"
             location: "[data-testid='text-location']"
-            link: "h2.jobTitle > a"
+            url: "h2.jobTitle > a"
             description_snippet: ".job-snippet"
           # cookie_modal_selectors and page_signatures would also go under indeed_config
         ```
@@ -246,7 +246,7 @@ profiles:
         job_card: ".job-tile"
         title: ".job-title"
         location: ".location"
-        link: "a" # Usually the whole card or title area is a link
+        url: "a" # Usually the whole card or title area is a link
       cookie_modal_selectors:
         - "#sp-cc-accept" # Example Amazon cookie button
       page_signatures:
@@ -294,7 +294,7 @@ profiles:
         title: "h2.jobTitle > a"
         company: "[data-testid='company-name']"
         location: "[data-testid='text-location']"
-        link: "h2.jobTitle > a"
+        url: "h2.jobTitle > a"
         description_snippet: ".job-snippet"
       cookie_modal_selectors:
         - "#onetrust-accept-btn-handler"

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -40,7 +40,7 @@ Extending the bot to support a new job site involves changes in configuration an
         *   `title`: Selector for the job title.
         *   `company`: Selector for the company name.
         *   `location`: Selector for the job location.
-        *   `link`: Selector for the direct link to the job posting.
+        *   `url`: Selector for the direct link to the job posting.
         *   `description_snippet`: (Optional) Selector for a brief job description.
     *   **`cookie_modal_selectors`**: (Optional) A list of CSS selectors for cookie consent buttons if the site has a cookie modal that needs to be handled by the generic `_handle_cookie_modal_generic` method.
     *   **`page_signatures`**: (Highly Recommended) A list of page signature objects. This is essential for the `identify_page_type()` system to correctly recognize different pages on the new site (e.g., search results, login pages, cookie modals). Refer extensively to the [Page Identification System Guide](./configuring_page_identification.md) for how to structure these.
@@ -54,7 +54,7 @@ Extending the bot to support a new job site involves changes in configuration an
         title: "h2.job-title"
         company: "span.company-name"
         location: "span.job-location"
-        link: "a.job-details-link"
+        url: "a.job-details-link"
       cookie_modal_selectors: ["button#accept-cookies-btn"]
       page_signatures:
         - page_type: "COOKIE_MODAL"
@@ -116,10 +116,10 @@ Create the following methods within the `BrowserActor` class:
     *   Use `self.page.wait_for_selector(job_card_selector, timeout=...)` to ensure job cards are present.
     *   Get all job card elements: `job_elements = self.page.locator(job_card_selector).all()`.
     *   Loop through `job_elements`. For each element:
-        *   Extract `title`, `company`, `location`, `link`, and `description` using the configured selectors and Playwright's `element.locator().first.text_content()` or `element.locator().first.get_attribute('href')`.
+        *   Extract `title`, `company`, `location`, the job `url`, and `description` using the configured selectors and Playwright's `element.locator().first.text_content()` or `element.locator().first.get_attribute('href')`.
         *   Use `try-except` blocks for each piece of data to handle cases where a selector might not find an element in a particular card.
-        *   Ensure links are absolute using `urllib.parse.urljoin(base_url, relative_link)`.
-        *   Append a dictionary of the extracted job data to a list. Include `source: '[New Site Name]'`.
+        *   Ensure URLs are absolute using `urllib.parse.urljoin(base_url, relative_link)`.
+        *   Append a dictionary of the extracted job data (`{"url": ..., "title": ..., "company": ...}`) to a list. Include `source: '[New Site Name]'`.
     *   Return the list of job dictionaries.
 
 3.  **Login Methods (If Applicable)**


### PR DESCRIPTION
## Summary
- document the job `url` field in configuration guide
- update developer guide to mention `url` instead of `link`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `markdownlint docs/*.md` *(fails: command not found)*
- `mkdocs build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684c7f6ec5cc8326960d14c7c8b01173